### PR TITLE
Add pandas to CPU requirement.txt which needed by wide_deep

### DIFF
--- a/byte_mlperf/backends/CPU/requirements.txt
+++ b/byte_mlperf/backends/CPU/requirements.txt
@@ -11,3 +11,4 @@ tensorflow==2.4.0
 onnxruntime
 torch==1.9.1
 sentencepiece==0.1.96
+pandas==1.3.3

--- a/byte_mlperf/backends/IPU/interact_infos/albert-torch-fp32.json
+++ b/byte_mlperf/backends/IPU/interact_infos/albert-torch-fp32.json
@@ -1,7 +1,7 @@
 {
   "clients": 1,
   "batch_sizes": [
-    32
+    4, 32
   ],
   "pack": true,
   "runtime_options": {

--- a/byte_mlperf/backends/IPU/interact_infos/bert-torch-fp32.json
+++ b/byte_mlperf/backends/IPU/interact_infos/bert-torch-fp32.json
@@ -1,7 +1,7 @@
 {
   "clients": 1,
   "batch_sizes": [
-    36
+    4, 36
   ],
   "pack": true,
   "runtime_options": {

--- a/byte_mlperf/backends/IPU/interact_infos/conformer-encoder-onnx-fp32.json
+++ b/byte_mlperf/backends/IPU/interact_infos/conformer-encoder-onnx-fp32.json
@@ -1,7 +1,7 @@
 {
   "clients": 4,
   "batch_sizes": [
-    32
+    4, 32
   ],
   "converter_options": {
     "precision": "fp16",

--- a/byte_mlperf/backends/IPU/interact_infos/resnet50-torch-fp32.json
+++ b/byte_mlperf/backends/IPU/interact_infos/resnet50-torch-fp32.json
@@ -1,6 +1,6 @@
 {
   "clients": 4,
-  "batch_sizes":[32],
+  "batch_sizes":[4, 32],
   "converter_options": {
     "precision": "fp16"
   },

--- a/byte_mlperf/backends/IPU/interact_infos/roformer-tf-fp32.json
+++ b/byte_mlperf/backends/IPU/interact_infos/roformer-tf-fp32.json
@@ -1,7 +1,7 @@
 {
   "clients": 1,
   "batch_sizes": [
-    12
+    2, 12
   ],
   "converter_options": {
     "precision": "fp16",

--- a/byte_mlperf/backends/IPU/interact_infos/widedeep-tf-fp32.json
+++ b/byte_mlperf/backends/IPU/interact_infos/widedeep-tf-fp32.json
@@ -1,5 +1,5 @@
 {
-    "batch_sizes": [20000],
+    "batch_sizes": [1024, 20000],
     "clients":5,
     "converter_options":{
         "precision": "fp16"


### PR DESCRIPTION
为每个模型添加workload中最小的那个batch size，是accuracy check需要。