### PR TITLE
Release the engine before create a new one

### DIFF
--- a/byte_mlperf/backends/IPU/runtime_backend_ipu.py
+++ b/byte_mlperf/backends/IPU/runtime_backend_ipu.py
@@ -53,6 +53,8 @@ class RuntimeBackendIPU(runtime_backend.RuntimeBackend):
             runtime_options = interact_info.get("runtime_options", {})
 
             if self.runner_name == "POPRT":
+                if self.engine:
+                    del self.engine
                 self.engine = engine_poprt.PopRT(self.popef_path, runtime_options)
             else:
                 raise ValueError("engine_name must be POPRT")


### PR DESCRIPTION
在创建新的engine前，释放当前的engine，以释放IPU资源。