### PR TITLE
[General] fixed minor bugs

### DIFF
--- a/byte_mlperf/core/perf_engine.py
+++ b/byte_mlperf/core/perf_engine.py
@@ -251,7 +251,7 @@ class PerfEngine:
         base_report.pop("Backend")
         log.info("Testing Finish. Report is saved in path: [ {}/{} ]".
                  format(output_dir[output_dir.rfind('byte_mlperf'):],
-                 output_report_path))
+                 os.path.basename(output_report_path)))
         build_pdf(output_report_path)
         log.info("PDF Version is saved in path: [ {}/{}-TO-{}.pdf ]".format(
             output_dir[output_dir.rfind('byte_mlperf'):],

--- a/byte_mlperf/requirements.txt
+++ b/byte_mlperf/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
 pandas
 virtualenv==16.7.9
-sklearn
+scikit-learn
 prompt_toolkit
 tqdm
 opencv-python


### PR DESCRIPTION
1. 修正report保存路径logging的错误:
INFO:PerfEngine:Testing Finish. Report is saved in path: [ byte_mlperf/reports/IPU/clip-onnx-fp32//ByteMLPerf/byte_mlperf/reports/IPU/clip-onnx-fp32/result-fp16.json ]

2. 修正pip install sklearn deprecated的错误，此前会报warning，稍早前会直接报error