### PR TITLE
修复已知BUG，增加feature

### DIFF
--- a/byte_infer_perf/llm_perf/README.md
+++ b/byte_infer_perf/llm_perf/README.md
@@ -1,11 +1,32 @@
 # Byte LLM Perf
 
-## HOW TO USE
+Vendors can refer to this document for guidance on building backend: [Byte LLM Perf](https://bytedance.larkoffice.com/docx/ZoU7dkPXYoKtJtxlrRMcNGMwnTc)
 
-1. define workloads config at `llm_perf/workloads/`
-2. implement backend inference code at `llm_perf/backends/`
-3. start perf test with following command, e.g. start perf test chatglm with GPU backend 
+## Requirements
+* Python >= 3.8
+* torch==2.1.0
 
-```bash
-python3 byte_infer_perf/llm_perf/core/perf_engine.py --task chatglm-torch-fp16-6b --hardware_type GPU
+## Installation
+```shell
+pip3 install torch==2.0.1
+pip3 install -r requirements.txt
 ```
+
+## Quick Start
+Please be sure to complete the installation steps before proceeding with the following steps.
+
+To start llm_perf, there are 3 steps:
+1. Download opensource model weights(.pt file)
+2. Download model output logits in specific input case(.npy file)
+3. Start accuracy and performance test case
+
+You can run following command automate all steps with chatglm2 model on GPU backend
+```shell
+python3 byte_infer_perf/llm_perf/core/perf_engine.py --task chatglm2-torch-fp16-6b --hardware_type GPU
+```
+
+## Models
+The list of supported models is:
+* ChatGLM
+* ChatGLM2
+* Chinese-LLaMA-2

--- a/byte_infer_perf/llm_perf/backends/GPU/common.py
+++ b/byte_infer_perf/llm_perf/backends/GPU/common.py
@@ -1,5 +1,9 @@
 import os
+import queue
+from multiprocessing import managers
 from typing import Any, Dict, List
+
+import torch
 
 from llm_perf.core import common
 
@@ -12,3 +16,46 @@ class Packet(common.Packet):
 
     def _is_finished(self) -> bool:
         return self.is_finished()
+
+
+class GPUMultiProcessMsgr(common.MultiProcessMsgr, managers.BaseManager):
+    def __init__(self, local_rank: int, world_size: int, name: str):
+        self.rank = local_rank
+        self.world_size = world_size
+
+        def make_message_queue(rank):
+            if rank != 0:
+                return None
+            new_queue = queue.Queue()
+            return lambda: new_queue
+
+        for i in range(1, world_size):
+            self.register(f"message_queue_{i}", callable=make_message_queue(local_rank))
+        if local_rank == 0:
+            super().__init__(authkey=name.encode("utf-8"))
+            self.start()
+            addr = [self.address]
+            torch.distributed.broadcast_object_list(addr, device=f"cuda:{local_rank}")
+            self.msg_queue_list = [
+                getattr(self, f"message_queue_{rank}")()
+                for rank in range(1, world_size)
+            ]
+        else:
+            addr = [None]
+            torch.distributed.broadcast_object_list(addr, device=f"cuda:{local_rank}")
+            super().__init__(address=addr[0], authkey=name.encode("utf-8"))
+            self.connect()
+            self.msg_queue = getattr(self, f"message_queue_{local_rank}")()
+
+    def broadcast(self, obj):
+        assert (
+            self.rank == 0
+        ), f"InterProcessMessager broadcast_message only allow rank0 to call!"
+        for rank in range(1, self.world_size):
+            self.msg_queue_list[rank - 1].put(obj)
+
+    def receive(self):
+        assert (
+            self.rank > 0
+        ), f"InterProcessMessager receive_message don't allow rank0 to call!"
+        return self.msg_queue.get()

--- a/byte_infer_perf/llm_perf/backends/GPU/gpu_engine_chatglm.py
+++ b/byte_infer_perf/llm_perf/backends/GPU/gpu_engine_chatglm.py
@@ -7,6 +7,7 @@ import torch
 from torch import distributed as dist
 from transformers import AutoModel, AutoTokenizer, PreTrainedTokenizer
 
+from llm_perf.backends.GPU.common import GPUMultiProcessMsgr
 from llm_perf.core.common import Packet
 from llm_perf.core.engine import CoreEngine
 from llm_perf.utils.logger import logger
@@ -29,10 +30,14 @@ class GpuEngineChatGLM(CoreEngine):
             self.local_rank = 0
             self.world_size = 1
 
+        if self.world_size > 1:
+            self.mlp_manager = GPUMultiProcessMsgr(
+                self.local_rank, self.world_size, "MultiProcessMsgr"
+            )
+
         self.tokenizer = tokenizer
         self.pad_token_id = tokenizer.pad_token_id
         self.max_bs = max_batch_size
-        self.max_position_embeddings = 2048
 
         self.init_inference(modelcls, model_config)
 
@@ -48,20 +53,21 @@ class GpuEngineChatGLM(CoreEngine):
 
         logger.info(f"cuda model {model_config['model_path']} loaded {self.model}")
 
-    def broadcast_inputs(self, **kwargs):
+    def broadcast_inputs(self, *args):
         if self.world_size <= 1:
-            return kwargs
+            return args
+
         if self.local_rank == 0:
-            object_list = [kwargs]
-            dist.broadcast_object_list(object_list, device=f"cuda:{self.local_rank}")
+            self.mlp_manager.broadcast(args)
+            return args
         else:
-            object_list = [None]
-            dist.broadcast_object_list(object_list, device=f"cuda:{self.local_rank}")
-        return object_list[0]
+            inputs = self.mlp_manager.receive()
+            return inputs
 
     def prepare_inputs(self, batch: List[Packet]):
         # TODO: chatglm is left padding, get wrong input when batching
         all_input_ids = []
+        all_position_ids = []
         max_seq_len = -1
         for packet in batch:
             if len(packet.request.input_ids) + len(packet.generate_ids) > max_seq_len:
@@ -76,22 +82,25 @@ class GpuEngineChatGLM(CoreEngine):
                 + [self.pad_token_id] * pad_len
             )
             all_input_ids.append(input_ids)
+            all_position_ids.append([i for i in range(max_seq_len)])
 
-        input_ids_tensor = torch.tensor(all_input_ids).view(-1, max_seq_len).cuda()
-        return self.model.prepare_inputs_for_generation(input_ids_tensor)
+        model_inputs = {
+            "past_key_values": None,
+            "attention_mask": None,
+            "use_cache": None,
+        }
+        model_inputs["input_ids"] = all_input_ids
+        model_inputs["position_ids"] = all_position_ids
+        return model_inputs
 
     def do_inference(self, packets: List[Packet]):
         torch.cuda.set_device(self.local_rank)
-        if self.local_rank == 0:
-            model_inputs = self.prepare_inputs(packets)
-        else:
-            model_inputs = {}
 
-        model_inputs = self.broadcast_inputs(**model_inputs)
+        model_inputs = self.prepare_inputs(packets) if self.local_rank == 0 else None
+        model_inputs = self.broadcast_inputs(model_inputs)[0]
 
-        if len(model_inputs) == 0:
-            time.sleep(0.1)
-            return
+        model_inputs["input_ids"] = torch.tensor(model_inputs["input_ids"])
+        model_inputs["position_ids"] = torch.tensor(model_inputs["position_ids"])
 
         for k, v in model_inputs.items():
             if isinstance(v, torch.Tensor):

--- a/byte_infer_perf/llm_perf/backends/GPU/gpu_engine_chinese_llama2.py
+++ b/byte_infer_perf/llm_perf/backends/GPU/gpu_engine_chinese_llama2.py
@@ -7,6 +7,7 @@ import torch
 from torch import distributed as dist
 from transformers import AutoModel, AutoTokenizer, PreTrainedTokenizer
 
+from llm_perf.backends.GPU.common import GPUMultiProcessMsgr
 from llm_perf.core.common import Packet
 from llm_perf.core.engine import CoreEngine
 from llm_perf.utils.logger import logger
@@ -29,10 +30,14 @@ class GpuEngineChineseLlama2(CoreEngine):
             self.local_rank = 0
             self.world_size = 1
 
+        if self.world_size > 1:
+            self.mlp_manager = GPUMultiProcessMsgr(
+                self.local_rank, self.world_size, "MultiProcessMsgr"
+            )
+
         self.tokenizer = tokenizer
         self.pad_token_id = tokenizer.pad_token_id
         self.max_bs = max_batch_size
-        self.max_position_embeddings = 2048
 
         self.init_inference(modelcls, model_config)
 
@@ -48,19 +53,20 @@ class GpuEngineChineseLlama2(CoreEngine):
 
         logger.info(f"cuda model {model_config['model_path']} loaded {self.model}")
 
-    def broadcast_inputs(self, **kwargs):
+    def broadcast_inputs(self, *args):
         if self.world_size <= 1:
-            return kwargs
+            return args
+
         if self.local_rank == 0:
-            object_list = [kwargs]
-            dist.broadcast_object_list(object_list, device=f"cuda:{self.local_rank}")
+            self.mlp_manager.broadcast(args)
+            return args
         else:
-            object_list = [None]
-            dist.broadcast_object_list(object_list, device=f"cuda:{self.local_rank}")
-        return object_list[0]
+            inputs = self.mlp_manager.receive()
+            return inputs
 
     def prepare_inputs(self, batch: List[Packet]) -> Dict:
         all_input_ids = []
+        all_position_ids = []
         max_seq_len = -1
         for packet in batch:
             if len(packet.request.input_ids) + len(packet.generate_ids) > max_seq_len:
@@ -75,22 +81,25 @@ class GpuEngineChineseLlama2(CoreEngine):
                 + [self.pad_token_id] * pad_len
             )
             all_input_ids.append(input_ids)
+            all_position_ids.append([i for i in range(max_seq_len)])
 
-        input_ids_tensor = torch.tensor(all_input_ids).view(-1, max_seq_len).cuda()
-        return self.model.prepare_inputs_for_generation(input_ids_tensor)
+        model_inputs = {
+            "past_key_values": None,
+            "attention_mask": None,
+            "use_cache": None,
+        }
+        model_inputs["input_ids"] = all_input_ids
+        model_inputs["position_ids"] = all_position_ids
+        return model_inputs
 
     def do_inference(self, packets: List[Packet]):
         torch.cuda.set_device(self.local_rank)
-        if self.local_rank == 0:
-            model_inputs = self.prepare_inputs(packets)
-        else:
-            model_inputs = {}
 
-        model_inputs = self.broadcast_inputs(**model_inputs)
+        model_inputs = self.prepare_inputs(packets) if self.local_rank == 0 else None
+        model_inputs = self.broadcast_inputs(model_inputs)[0]
 
-        if len(model_inputs) == 0:
-            time.sleep(0.1)
-            return
+        model_inputs["input_ids"] = torch.tensor(model_inputs["input_ids"])
+        model_inputs["position_ids"] = torch.tensor(model_inputs["position_ids"])
 
         for k, v in model_inputs.items():
             if isinstance(v, torch.Tensor):

--- a/byte_infer_perf/llm_perf/backends/GPU/model_impl/__init__.py
+++ b/byte_infer_perf/llm_perf/backends/GPU/model_impl/__init__.py
@@ -1,5 +1,5 @@
 ## __all__ is a dict:
-##   key is model_name in config_chatglm.json
+##   key is model_name in `model_zoo/chatglm-xx.json`
 ##   value is vendor specify model impl
 # __all__ = {
 #     "chatglm" : ChatGLMForConditionalGeneration,

--- a/byte_infer_perf/llm_perf/benchmark/bench.py
+++ b/byte_infer_perf/llm_perf/benchmark/bench.py
@@ -1,28 +1,28 @@
-import argparse
-import csv
-import json
 import multiprocessing as mp
 import os
+import random
 import sys
 import time
-from typing import Iterable, List
+from typing import Any, AsyncIterable, Callable, Dict, Iterable, List
 
+import backoff
 import grpc
-import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from llm_perf.utils.logger import logger, setup_logger
+from llm_perf.utils.logger import logger
+from llm_perf.utils.reporter import ReportType
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 from llm_perf import server_pb2, server_pb2_grpc
 from llm_perf.utils.pb import deserialize_value, serialize_value
-from llm_perf.utils.reporter import Reporter
 
 
-def gen_request(
+@backoff.on_exception(backoff.expo, Exception, factor=0.1, max_value=1, max_tries=3)
+def gen_stream_request(
     stub: server_pb2_grpc.InferenceStub,
+    index: int,
     prompt: str,
     min_new_tokens: int,
     max_new_tokens: int,
@@ -31,7 +31,7 @@ def gen_request(
     get_input_logits: int,
 ) -> Iterable[server_pb2.InferenceResponse]:
     req = server_pb2.InferenceRequest(
-        req_id=str(os.getpid()) + "_" + str(int(time.time())),
+        req_id=str(index) + "_" + str(int(time.time())),
         inputs={
             "input_messages": serialize_value(prompt),
             "min_new_tokens": serialize_value(min_new_tokens),
@@ -41,7 +41,7 @@ def gen_request(
             "get_input_logits": serialize_value(get_input_logits),
         },
     )
-    for res in stub.StreamingInference(req):
+    for res in stub.StreamingInference(req, wait_for_ready=False):
         yield res
 
 
@@ -53,202 +53,108 @@ def format_question(line) -> str:
     return question
 
 
-def bench(
-    backend: str, workload: dict, model_config: dict, result_queue: mp.Queue, args
-):
-    dataset: pd.DataFrame = pd.read_csv(model_config["dataset"])
-    channel = grpc.insecure_channel(f"{args.host}:{args.port}")
-    stub = server_pb2_grpc.InferenceStub(channel)
-    buffer_dump_file: List[str] = []
+def bench_accuracy(stub, workload: Dict[str, Any], result_queue: mp.Queue):
+    dataset: pd.DataFrame = pd.read_csv(workload["dataset"])
+    result_queue.put("@start")
     for row_index, row in tqdm(dataset.iterrows(), total=len(dataset)):
         question = format_question(row)
-        st = time.time()
-        generate_tokens_len = 0
-        first_token_latency = 0
-        output_messages: str = ""
-        ppl: List[float] = []
-        for res in gen_request(
+        perplexity_list: List[float] = []
+        for res in gen_stream_request(
             stub,
-            question,
-            workload["min_new_tokens"],
-            workload["max_new_tokens"],
-            args.top_p,
-            args.top_k,
+            index=1,
+            prompt=question,
+            min_new_tokens=workload["min_new_tokens"],
+            max_new_tokens=workload["max_new_tokens"],
+            top_p=0,
+            top_k=1,  # use greedy search for accuracy bench
+            get_input_logits=1,
         ):
-            if not first_token_latency:
-                first_token_latency = time.time() - st
-
             res = {k: deserialize_value(v) for k, v in res.outputs.items()}
-            output_messages += res["output_messages"]
-            _ppl = res["ppl"]
-            logger.debug(f"get ppl: {_ppl}")
-            ppl.append(_ppl)
+            perplexity = res["choice"]["perplexity"]
+            logits_dump = res["choice"]["logits_dump"]
+            if not logits_dump:
+                perplexity_list.append(perplexity)
 
-        dump_file = res["dump_file"]
-        if dump_file != "":
-            buffer_dump_file.append(dump_file)
-        else:
-            logger.debug(f"Dump logits diff disabled")
-
-        generate_tokens_len = len(output_messages)
-
-        use_time = time.time() - st
-        per_token_latency = use_time / generate_tokens_len
-
-        result = {
-            "prompt_tokens": question,
-            "prompt_tokens_len": len(question),
-            "output_message": output_messages,
-            "generate_tokens_len": generate_tokens_len,
-            "first_token_latency": first_token_latency,
-            "per_token_latency": per_token_latency,
-            "ppl": ppl,
-            "dump_file": dump_file,
-        }
+        result = {"perplexity": perplexity_list, "logits_dump": logits_dump}
         logger.debug(f"prompt response: {result}")
         result_queue.put(result)
 
     result_queue.put(None)
-    logger.debug(f"buffer numpy files: {buffer_dump_file}")
 
 
 def bench_performance(
-    backend: str, workload: dict, model_config: dict, result_queue: mp.Queue, args
+    stub,
+    index: int,
+    workload: Dict[str, Any],
+    input_tokens: int,
+    result_queue: mp.Queue,
 ):
-    dataset: pd.DataFrame = pd.read_csv(model_config["dataset"])
-    channel = grpc.insecure_channel(f"{args.host}:{args.port}")
-    stub = server_pb2_grpc.InferenceStub(channel)
-    for row_index, row in tqdm(dataset.iterrows(), total=len(dataset)):
-        question = format_question(row)
+    result_queue.put("@start")
+    perf_start = time.time()
+    perf_time: int = workload["perf_time"]
+    bar = tqdm(total=perf_time, unit="s")
+    while perf_start + perf_time > time.time():
+        prompt = "我" * input_tokens
         st = time.time()
-        generate_tokens_len = 0
         first_token_latency = 0
         output_messages: str = ""
-        for res in gen_request(
+        for res in gen_stream_request(
             stub,
-            question,
-            workload["min_new_tokens"],
-            workload["max_new_tokens"],
-            args.top_p,
-            args.top_k,
-            0,
+            index=index,
+            prompt=prompt,
+            min_new_tokens=workload["min_new_tokens"],
+            max_new_tokens=workload["max_new_tokens"],
+            top_p=0,
+            top_k=1,
+            get_input_logits=0,
         ):
+            res = {k: deserialize_value(v) for k, v in res.outputs.items()}
+            output_messages += res["choice"]["message"]
+
             if not first_token_latency:
                 first_token_latency = time.time() - st
 
-            res = {k: deserialize_value(v) for k, v in res.outputs.items()}
-            output_messages += res["output_messages"]
-
-        generate_tokens_len = len(output_messages)
-
         use_time = time.time() - st
-        per_token_latency = use_time / generate_tokens_len
+        prompt_tokens = res["usage"]["prompt_tokens"]
+        completion_tokens = res["usage"]["completion_tokens"]
+        per_token_latency = use_time / completion_tokens
 
         result = {
-            "prompt_tokens": question,
-            "prompt_tokens_len": len(question),
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
             "output_message": output_messages,
-            "generate_tokens_len": generate_tokens_len,
             "first_token_latency": first_token_latency,
             "per_token_latency": per_token_latency,
         }
-        logger.debug(f"prompt response: {result}")
+        logger.debug(f"bench_{index} prompt response: {result}")
         result_queue.put(result)
+        bar.update(use_time)
 
+    bar.close()
     result_queue.put(None)
 
 
-def bench_accuracy(
-    backend: str, workload: dict, model_config: dict, result_queue: mp.Queue, args
+def benchmark(
+    index: int,
+    workload: Dict[str, Any],
+    report_type: ReportType,
+    input_tokens: int,
+    result_queue: mp.Queue,
+    args,
 ):
-    dataset: pd.DataFrame = pd.read_csv(model_config["dataset"])
-    channel = grpc.insecure_channel(f"{args.host}:{args.port}")
-    stub = server_pb2_grpc.InferenceStub(channel)
-    for row_index, row in tqdm(dataset.iterrows(), total=len(dataset)):
-        question = format_question(row)
-        prompt_ppl: List[float] = []
-        for res in gen_request(
-            stub,
-            question,
-            workload["min_new_tokens"],
-            workload["max_new_tokens"],
-            args.top_p,
-            args.top_k,
-            1,
-        ):
-            res = {k: deserialize_value(v) for k, v in res.outputs.items()}
-            ppl = res["ppl"]
-            prompt_ppl.append(ppl)
+    logger.debug(f"{report_type.name} bench_{index} start")
 
-        dump_file = res["dump_file"]
+    with grpc.insecure_channel(f"{args.host}:{args.port}") as channel:
+        stub = server_pb2_grpc.InferenceStub(channel)
+        time.sleep(random.randint(0, 10))
 
-        result = {"ppl": prompt_ppl, "dump_file": dump_file}
-        logger.debug(f"prompt response: {result}")
-        result_queue.put(result)
+        try:
+            if report_type == ReportType.ACCURACY:
+                bench_accuracy(stub, workload, result_queue)
+            elif report_type == ReportType.PERFORMANCE:
+                bench_performance(stub, index, workload, input_tokens, result_queue)
+        except Exception as e:
+            logger.error(f"{report_type.name} bench_{index} error: {e}")
+            raise e
 
-    result_queue.put(None)
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--dataset", type=str, required=True)
-    parser.add_argument("--min-new-tokens", type=int, required=True)
-    parser.add_argument("--max-new-tokens", type=int, required=True)
-    parser.add_argument("--top-p", type=float, required=True)
-    parser.add_argument("--top-k", type=int, required=True)
-    parser.add_argument("--batch-size", type=int, required=True)
-    parser.add_argument("--host", type=str, required=True)
-    parser.add_argument("--port", type=str, required=True)
-    parser.add_argument("--task", type=str, required=True)
-    parser.add_argument("--hardware_type", "-hw", type=str, required=True)
-    parser.add_argument("--device_count", type=int, required=True)
-    args = parser.parse_args()
-
-    loglevel = os.environ.get("LOG_LEVEL", "debug")
-    setup_logger(loglevel)
-
-    dataset: pd.DataFrame = pd.read_csv(args.dataset)
-
-    result_queue = mp.Queue()
-    jobs: List[mp.Process] = []
-
-    for i in range(args.batch_size):
-        p = mp.Process(
-            target=bench,
-            args=(
-                args.dataset,
-                args.hardware_type,
-                args.task,
-                dataset,
-                result_queue,
-                args,
-            ),
-        )
-        jobs.append(p)
-        p.start()
-
-    reporter = Reporter(
-        args.batch_size,
-        args.task,
-        args.hardware_type,
-        args.device_count,
-        args.min_new_tokens,
-        args.max_new_tokens,
-    )
-    reporter.start()
-    while True:
-        result = result_queue.get()
-        if result is None:
-            break
-
-        reporter.submit(result)
-
-    for p in jobs:
-        p.join()
-
-    reporter.stop()
-    reporter.summary()
-
-
-if __name__ == "__main__":
-    main()
+    logger.debug(f"{report_type.name} bench_{index} finish")

--- a/byte_infer_perf/llm_perf/launch.py
+++ b/byte_infer_perf/llm_perf/launch.py
@@ -1,13 +1,55 @@
 import argparse
+import asyncio
+import importlib
+import json
 import os
 import sys
+from typing import Any, Dict
 
 BYTE_MLPERF_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(BYTE_MLPERF_ROOT)
 sys.path.insert(0, BYTE_MLPERF_ROOT)
 
+from llm_perf.core.infernecer import CoreInferencer
 from llm_perf.server.serve import serve
-from llm_perf.utils.logger import setup_logger
+from llm_perf.utils.logger import logger, setup_logger
+
+
+def get_model_impl(model_config: Dict[str, Any], hardware_type: str):
+    model_inferface = model_config["model_interface"]
+    model_name = model_config["model_name"]
+
+    # Get orig model
+    spec = importlib.util.spec_from_file_location(
+        model_name, f"llm_perf/model_zoo/{model_name.split('-')[0]}.py"
+    )
+    base_module_impl = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(base_module_impl)
+
+    orig_model = getattr(base_module_impl, model_inferface)
+
+    # Get vendor model
+    vendor_model_path = f"llm_perf/backends/{hardware_type}/model_impl"
+    if not os.path.exists(vendor_model_path):
+        logger.info(
+            f"{vendor_model_path} not exists, {model_inferface} model select <ByteMLPerf base model>"
+        )
+        return orig_model
+
+    vendor_model_impl = importlib.import_module(
+        ".", package=vendor_model_path.replace("/", ".")
+    )
+    if not model_name in vendor_model_impl.__all__.keys():
+        logger.info(
+            f"can't find {model_name} in {vendor_model_path}/__init__, model select <ByteMLPerf base model>"
+        )
+        return orig_model
+
+    vendor_model = vendor_model_impl.__all__[model_name]
+    logger.info(
+        f"find {model_inferface} in {vendor_model_path}, model select <Vendor model>"
+    )
+    return vendor_model
 
 
 def main():
@@ -18,10 +60,36 @@ def main():
     parser.add_argument("--max_batch_size", type=int, required=True)
     args = parser.parse_args()
 
-    loglevel = os.environ.get("LOG_LEVEL", "debug")
+    loglevel = os.environ.get("LOG_LEVEL", "info")
     setup_logger(loglevel)
 
-    serve(args)
+    # Get Model config
+    config_path = "llm_perf/model_zoo/" + args.task + ".json"
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            model_config = json.load(f)
+            logger.info(f"load model config: {config_path}")
+    else:
+        logger.error(
+            f"{config_path} not exists! The json file corresponding to the task {task} cannot be found. \
+            Please confirm whether the file path is correct."
+        )
+        sys.exit(1)
+
+    setup = importlib.import_module(
+        ".setup", package=f"llm_perf.backends.{args.hardware_type}"
+    )
+    logger.info(f"import setup: {setup}")
+
+    model_impl = get_model_impl(model_config, args.hardware_type)
+
+    scheduler = setup.setup_scheduler(
+        model_impl, model_config, max_batch_size=args.max_batch_size
+    )
+
+    inferencer = CoreInferencer(scheduler)
+
+    asyncio.run(serve(args, inferencer))
 
 
 if __name__ == "__main__":

--- a/byte_infer_perf/llm_perf/model_zoo/chatglm-torch-fp16-6b.json
+++ b/byte_infer_perf/llm_perf/model_zoo/chatglm-torch-fp16-6b.json
@@ -33,6 +33,5 @@
     "tokenizer": {
         "path": "llm_perf/model_zoo/sota/chatglm-torch-fp16-6b",
         "add_sep_token": false
-    },
-    "dataset": "llm_perf/datasets/merged_52_test.csv"
+    }
 }

--- a/byte_infer_perf/llm_perf/model_zoo/chatglm2-torch-fp16-6b.json
+++ b/byte_infer_perf/llm_perf/model_zoo/chatglm2-torch-fp16-6b.json
@@ -47,6 +47,5 @@
     "tokenizer": {
         "path": "llm_perf/model_zoo/sota/chatglm2-torch-fp16-6b",
         "add_sep_token": false
-    },
-    "dataset": "llm_perf/datasets/merged_52_test.csv"
+    }
 }

--- a/byte_infer_perf/llm_perf/model_zoo/chinese-llama2-torch-fp16-13b.json
+++ b/byte_infer_perf/llm_perf/model_zoo/chinese-llama2-torch-fp16-13b.json
@@ -30,6 +30,5 @@
     "tokenizer": {
         "path": "llm_perf/model_zoo/sota/chinese-llama2-torch-fp16-13b",
         "add_sep_token": false
-    },
-    "dataset": "llm_perf/datasets/merged_52_test.csv"
+    }
 }

--- a/byte_infer_perf/llm_perf/requirements.txt
+++ b/byte_infer_perf/llm_perf/requirements.txt
@@ -8,3 +8,4 @@ google-api-python-client
 transformers==4.33.2
 tqdm
 matplotlib
+backoff

--- a/byte_infer_perf/llm_perf/server/serve.py
+++ b/byte_infer_perf/llm_perf/server/serve.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 from concurrent import futures
-from typing import Any, Dict, Iterable, List
+from typing import Any, AsyncIterable, Dict, Iterable, List
 
 import grpc
 
@@ -18,74 +18,13 @@ from llm_perf.utils.pb import deserialize_value, serialize_value
 
 
 class Inference(server_pb2_grpc.InferenceServicer):
-    def __init__(self, task: str, hardware_type: str, max_batch_size: int) -> None:
+    def __init__(self, inferencer: CoreInferencer) -> None:
         super().__init__()
+        self.inferencer = inferencer
 
-        # Get Model config
-        config_path = "llm_perf/model_zoo/" + task + ".json"
-        if os.path.exists(config_path):
-            with open(config_path, "r") as f:
-                model_config = json.load(f)
-                logger.info(f"load model config: {config_path}")
-        else:
-            logger.error(
-                f"{config_path} not exists! The json file corresponding to the task {task} cannot be found. \
-                Please confirm whether the file path is correct."
-            )
-            sys.exit(1)
-
-        setup = importlib.import_module(
-            ".setup", package=f"llm_perf.backends.{hardware_type}"
-        )
-        logger.info(f"import setup: {setup}")
-
-        model_impl = self.get_model_impl(model_config, hardware_type)
-
-        scheduler = setup.setup_scheduler(
-            model_impl, model_config, max_batch_size=max_batch_size
-        )
-
-        self.inferencer = CoreInferencer(scheduler)
-
-    def get_model_impl(self, model_config: Dict[str, Any], hardware_type: str):
-        model_inferface = model_config["model_interface"]
-        model_name = model_config["model_name"]
-
-        # Get orig model
-        spec = importlib.util.spec_from_file_location(
-            model_name, f"llm_perf/model_zoo/{model_name.split('-')[0]}.py"
-        )
-        base_module_impl = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(base_module_impl)
-
-        orig_model = getattr(base_module_impl, model_inferface)
-
-        # Get vendor model
-        vendor_model_path = f"llm_perf/backends/{hardware_type}/model_impl"
-        if not os.path.exists(vendor_model_path):
-            logger.info(
-                f"{vendor_model_path} not exists, {model_inferface} model select <ByteMLPerf base model>"
-            )
-            return orig_model
-
-        vendor_model_impl = importlib.import_module(
-            ".", package=vendor_model_path.replace("/", ".")
-        )
-        if not model_name in vendor_model_impl.__all__.keys():
-            logger.info(
-                f"can't find {model_name} in {vendor_model_path}/__init__, model select <ByteMLPerf base model>"
-            )
-            return orig_model
-
-        vendor_model = vendor_model_impl.__all__[model_name]
-        logger.info(
-            f"find {model_inferface} in {vendor_model_path}, model select <Vendor model>"
-        )
-        return vendor_model
-
-    def StreamingInference(
+    async def StreamingInference(
         self, request: server_pb2.InferenceRequest, context: grpc.ServicerContext
-    ) -> Iterable[server_pb2.InferenceResponse]:
+    ) -> AsyncIterable[server_pb2.InferenceResponse]:
         logger.debug(f"StreamingInference request id {request.req_id}")
 
         req = {k: deserialize_value(v) for k, v in request.inputs.items()}
@@ -99,31 +38,30 @@ class Inference(server_pb2_grpc.InferenceServicer):
         }
 
         # Generating
-        for result in self.inferencer.streaming_inference(
+        async for result in self.inferencer.streaming_inference(
             prompt=prompt, generate_config=generate_config
         ):
             yield server_pb2.InferenceResponse(
                 req_id=request.req_id,
-                outputs={
-                    "output_messages": serialize_value(result["token"]),
-                    "ppl": serialize_value(result["ppl"]),
-                    "dump_file": serialize_value(result["dump_file"]),
-                },
+                outputs={k: serialize_value(v) for k, v in result.items()},
             )
 
 
-def serve(args) -> None:
-    server = grpc.server(thread_pool=futures.ThreadPoolExecutor(max_workers=10))
-    server_pb2_grpc.add_InferenceServicer_to_server(
-        Inference(args.task, args.hardware_type, args.max_batch_size), server
+async def serve(args, inferencer: CoreInferencer) -> None:
+    workers = min(os.cpu_count(), 100)
+    server = grpc.aio.server(
+        migration_thread_pool=futures.ThreadPoolExecutor(
+            max_workers=workers, thread_name_prefix="server"
+        )
     )
+    server_pb2_grpc.add_InferenceServicer_to_server(Inference(inferencer), server)
     server.add_insecure_port(f"[::]:{args.port}")
 
-    server.start()
+    await server.start()
     logger.info(f"GRPC Server start at {args.port}")
 
     fifo_name = "./server_fifo"
     with open(fifo_name, "w") as fifo_fd:
         fifo_fd.write("Server Ready")
         fifo_fd.flush()
-    server.wait_for_termination()
+    await server.wait_for_termination()

--- a/byte_infer_perf/llm_perf/utils/pb.py
+++ b/byte_infer_perf/llm_perf/utils/pb.py
@@ -19,6 +19,10 @@ def deserialize_value(value: server_pb2.Value) -> Any:
         return [v for v in value.int64_list.values]
     elif kind == "bytes_list":
         return [v for v in value.bytes_list.values]
+    elif kind == "string_list":
+        return [v for v in value.string_list.values]
+    elif kind == "struct_":
+        return {k: deserialize_value(v) for k, v in value.struct_.fields.items()}
     else:
         raise TypeError(f"Invalid type {type(value)}")
 
@@ -43,7 +47,7 @@ def serialize_value(value: Any) -> server_pb2.Value:
             return server_pb2.Value(string_list=server_pb2.StringList(values=value))
     elif isinstance(value, dict):
         return server_pb2.Value(
-            struct_=server_pb2.Value(
+            struct_=server_pb2.Struct(
                 fields={k: serialize_value(v) for k, v in value.items()}
             )
         )

--- a/byte_infer_perf/llm_perf/workloads/chatglm-torch-fp16-6b.json
+++ b/byte_infer_perf/llm_perf/workloads/chatglm-torch-fp16-6b.json
@@ -2,9 +2,11 @@
     "model": "chatglm-torch-fp16-6b",
     "test_accuracy": true,
     "test_perf": true,
-    "min_new_tokens": 0,
-    "max_new_tokens": 512,
-    "clients": 10,
-    "tp_sizes": [1, 2, 4, 8],
-    "batch_sizes":[4, 8, 16, 32]
+    "min_new_tokens": 128,
+    "max_new_tokens": 256,
+    "tp_sizes": [1, 2],
+    "batch_sizes":[1, 2, 4, 8],
+    "input_tokens": [1024, 2048],
+    "dataset": "llm_perf/datasets/merged_52_test.csv",
+    "perf_time": 180
 }

--- a/byte_infer_perf/llm_perf/workloads/chatglm2-torch-fp16-6b.json
+++ b/byte_infer_perf/llm_perf/workloads/chatglm2-torch-fp16-6b.json
@@ -1,10 +1,12 @@
 {
     "model": "chatglm2-torch-fp16-6b",
-    "test_accuracy": true,
+    "test_accuracy": false,
     "test_perf": true,
-    "min_new_tokens": 0,
-    "max_new_tokens": 512,
-    "clients": 10,
-    "tp_sizes": [1, 2, 4, 8],
-    "batch_sizes":[4, 8, 16, 32]
+    "min_new_tokens": 128,
+    "max_new_tokens": 256,
+    "tp_sizes": [1, 2],
+    "batch_sizes":[1, 2, 4, 8],
+    "input_tokens": [1024, 2048],
+    "dataset": "llm_perf/datasets/merged_52_test.csv",
+    "perf_time": 180
 }

--- a/byte_infer_perf/llm_perf/workloads/chinese-llama2-torch-fp16-13b.json
+++ b/byte_infer_perf/llm_perf/workloads/chinese-llama2-torch-fp16-13b.json
@@ -1,10 +1,12 @@
 {
     "model": "chinese-llama2-torch-fp16-13b",
-    "test_accuracy": true,
+    "test_accuracy": false,
     "test_perf": true,
-    "min_new_tokens": 0,
-    "max_new_tokens": 512,
-    "clients": 10,
-    "tp_sizes": [1, 2, 4, 8],
-    "batch_sizes":[4, 8, 16, 32]
+    "min_new_tokens": 128,
+    "max_new_tokens": 256,
+    "tp_sizes": [1, 2],
+    "batch_sizes":[1, 2, 4, 8],
+    "input_tokens": [1024, 2048],
+    "dataset": "llm_perf/datasets/merged_52_test.csv",
+    "perf_time": 180
 }


### PR DESCRIPTION
增加接入文档：https://bytedance.larkoffice.com/docx/ZoU7dkPXYoKtJtxlrRMcNGMwnTc

Bugfix:
    1. 在input长度比较小的时候，first token latency数据偏低（受框架开销影响较大）：scheduler获取请求方式从sleep/weakup/check切换为condition notify，减少延迟
    2. throughput计算的时候，分母的时间是加上了模型加载和server、client进程启动的总时间：开始计时时间从服务启动修正为每次client开始发起grpc请求，并且每轮测试reset计时
    3. 时延计算时，是按照字符串长度，不是按照token个数：修改GRPC协议，支持server端返回completion_tokens字段，每产生一个token增加1
    4. 压测时报timeout错误/压测时报grpc获取response失败：修改client数量为batch_size，避免大于worker数量时产生timeout，修改同步GRPC协议为异步GRPC，修改GRPC worker数量为最大100，避免有client饥饿。
    5. 修复精度测试 短output时，概率性logits dump文件被覆盖问题
    6. throughput计算时，修改使用当前时间为最后一次提交时间，减少误差

Feature:
    1. 抽象卡间通信类，实现GPU从NCCL修改为IPC，删除非RANK0卡周期sleep逻辑，进行堵塞获取请求，减少延迟
    2. 修改packet退出判断条件，支持finish_reaseon字段，后续可以通过GRPC返回给client（如需）
    3. 修改chatglm/chatglm2/llama2的inputs，从model接口改为手动构造，来支持多卡之间用python data通信而不是CUDA tensor
    4. benchmark client支持backoff重试策略
    5. performance 测试支持手动构造数据，例如自定义压测input长度为2048、output长度为256，压测并发数量为4时的延迟与吞吐性能
    6. 增加accuracy与performance测试格式、debug信息与exception处理
    7. server端GRPC从同步切换为异步，优化消息格式，支持accuracy与performance测试时不同的返回消息
    8. 修改model.json定义，删除dataset字段
    9. 修改workload.json定义，删除压测client，使用batch_size替代，增加input_tokens配置，增加perf_time配置，增加dataset配置
    10. 增加grpc序列化与反序列化对更多数据类型的适配