### PR TITLE
fix(flash_mla): fix a shape bug in flash_mla test

### DIFF
--- a/byte_micro_perf/backends/GPU/custom_ops.py
+++ b/byte_micro_perf/backends/GPU/custom_ops.py
@@ -267,7 +267,7 @@ class GPUFlashMLAOp(BasicOp):
                 device=self.backend.get_torch_device_name()
             )
             self.v = torch.randn(
-                self.batch_size, self.kv_seq_len, self.kv_head_num, self.qk_dim_size,
+                self.batch_size, self.kv_seq_len, self.kv_head_num, self.v_dim_size,
                 dtype=self.torch_dtype,
                 device=self.backend.get_torch_device_name()
             )
@@ -284,7 +284,7 @@ class GPUFlashMLAOp(BasicOp):
                     device=self.backend.get_torch_device_name()
                 ),
                 "v": OpTensorInfo(
-                    shape=[self.batch_size, self.kv_seq_len, self.kv_head_num, self.qk_dim_size],
+                    shape=[self.batch_size, self.kv_seq_len, self.kv_head_num, self.v_dim_size],
                     dtype=self.torch_dtype,
                     device=self.backend.get_torch_device_name()
                 )


### PR DESCRIPTION
The tensor 'self.v' shape was incorrectly set to 'self.qk_dim_size', while the correct dimension should be 'self.v_dim_size'.


1. 现状，self.v_dim_size仅仅用在了calc_flops，没有真实用到tensor size中；这里应该不太对；
2. 看了一下deepseek-r1 modeling中的设置，qk=192, v=128
综上，提交了这个PR。