### PR TITLE
修复在跑算子测试时，其余卡查询0卡的可用内存问题

### DIFF
--- a/byte_micro_perf/core/backend.py
+++ b/byte_micro_perf/core/backend.py
@@ -147,7 +147,7 @@ class Backend(ABC):
         tensor_size = op_instance.tensor_size
 
         # device
-        device_mem_info = self.get_mem_info()
+        device_mem_info = self.get_mem_info(self.true_device_index)
         avail_memory = device_mem_info[0]
 
         # assume

--- a/byte_micro_perf/core/scheduler.py
+++ b/byte_micro_perf/core/scheduler.py
@@ -237,6 +237,7 @@ class Scheduler:
                 true_device_index = backend.target_devices[true_rank]
                 print(f"true_world_size: {true_world_size}, true_rank: {true_rank}, true_device_index: {true_device_index}")
                 backend.set_device(true_device_index)
+                backend.true_device_index = true_device_index
 
                 # device process is ready
                 output_queues.put("ready")
@@ -291,6 +292,7 @@ class Scheduler:
                 true_device_index = backend.all_node_devices[true_rank]
                 print(f"true_world_size: {true_world_size}, true_rank: {true_rank}, true_device_index: {true_device_index}")
                 backend.set_device(true_device_index)
+                backend.true_device_index = true_device_index
 
                 # init dist env
                 dist_module = backend.get_dist_module()


### PR DESCRIPTION
修复在跑算子测试时，其余卡查询0卡的可用内存，导致实际内存充足，确报错内存不足的问题