### PR TITLE
fix: correct quantization variable, topk output dtype, and MoE IO est…

### DIFF
--- a/projects/micro_perf/op_defs/llm_ops/moe_quant_group_gemm.py
+++ b/projects/micro_perf/op_defs/llm_ops/moe_quant_group_gemm.py
@@ -133,7 +133,12 @@ class MoeQuantGroupGemmOp(BasicOp):
         ])
         self.tensor_size = self.input_tensor_size + self.output_tensor_size
 
-        self.read_bytes = self.input_tensor_size
+        # Subtract weight/scale bytes for inactive experts (no tokens dispatched)
+        inactive = self.num_experts_per_rank - sum(1 for c in self.expert_dispatch_token_count if c > 0)
+        inactive_bytes = inactive * self.new_hidden_size * (
+            self.hidden_size * self.input_tensor_info["experts_weight"].dtype.itemsize
+            + self.input_tensor_info["experts_scale"].dtype.itemsize)
+        self.read_bytes = self.input_tensor_size - inactive_bytes
         self.write_bytes = self.output_tensor_size
         self.io_bytes = self.read_bytes + self.write_bytes
 

--- a/projects/micro_perf/op_defs/llm_ops/moe_softmax_topk.py
+++ b/projects/micro_perf/op_defs/llm_ops/moe_softmax_topk.py
@@ -52,7 +52,7 @@ class MoeSoftmaxTopkOp(BasicOp):
         self.output_tensor_info = {
             "selected_experts": OpTensorInfo(
                 shape=[self.num_tokens, self.topk], 
-                dtype=self.torch_dtype, 
+                dtype=torch.int32,
                 device=self.backend.get_torch_device_name(),
             ), 
             "moe_weights": OpTensorInfo(

--- a/src/xpu_perf/micro_perf/core/utils.py
+++ b/src/xpu_perf/micro_perf/core/utils.py
@@ -625,7 +625,7 @@ def smooth_per_token_dynamic_quant(
     per_token_scale = per_token_max * max_dtype_val
 
     # [num_tokens, hidden_size], quantized
-    quant_tokens_fp32 = torch.mul(smooth_scale, per_token_scale).clamp(-max_dtype_val, max_dtype_val)
+    quant_tokens_fp32 = torch.mul(smoothed_input, per_token_scale).clamp(-max_dtype_val, max_dtype_val)
     if dst_torch_dtype == torch.int8:
         quant_tokens_fp32 = quant_tokens_fp32.round()
 


### PR DESCRIPTION
Fix three issues in micro_perf op definitions and core utils:

1. Fix wrong variable in smooth_per_token_dynamic_quant (src/xpu_perf/micro_perf/core/utils.py)

The smoothed_input is the actual smoothed tensor  instead of smooth_scale (the scaling factor)

2. Fix selected_experts output dtype in MoeSoftmaxTopkOp (projects/micro_perf/op_defs/llm_ops/moe_softmax_topk.py)

selected_experts is an index tensor and should be torch.int32, not the model's floating-point dtype.

3. Fix read_bytes estimation in MoeQuantGroupGemmOp (projects/micro_perf/op_defs/llm_ops/moe_quant_group_gemm.py)

Previously read_bytes included weight/scale data for all experts, but only experts with dispatched tokens are actually read. Subtract inactive experts' weight and scale bytes for a more accurate IO bandwidth estimate.