### PR TITLE
fix llm_sim run_mode override and latency.csv e2e formula

### DIFF
--- a/projects/xpu_oj/llm_sim/engine.py
+++ b/projects/xpu_oj/llm_sim/engine.py
@@ -379,7 +379,7 @@ class XpuPerfSimEngine:
                 perf = self.fix_data_dict[(bs, cl, ql)]["perf_info"]
                 stage_latency = round(perf["total_latency"], 3)
                 kernel_latency = round(perf["total_node_latency"], 3)
-                e2e_latency = round(stage_latency * self.dist_info.pp_size, 3)
+                e2e_latency = round(stage_latency * self.num_layers * self.dist_info.pp_size, 3)
                 lw.writerow(
                     {
                         "batch_size": bs,
@@ -784,7 +784,7 @@ class XpuPerfSimEngine:
 
 
         # 获取 bench_mode
-        self.run_mode = kwargs.get("run_mode", "prefill")
+        self.run_mode = kwargs.get("run_mode", self.run_mode)
         self.ori_num_layers = self.model_config.num_layers[0]
         self.test_num_layers = self.ori_num_layers
         num_layers = self.ori_num_layers


### PR DESCRIPTION
## Summary

Two verified correctness bugs in `projects/xpu_oj/llm_sim/engine.py`, each a one-line fix.

### 1. `--run_mode decode` was silently ignored (engine.py:787)

`parse_model()` re-derived `run_mode` via `kwargs.get("run_mode", "prefill")`. But `kwargs` can never contain `run_mode`: it is a positional ctor arg (a keyword call binds to the parameter, not `**kwargs`), and the only real kwargs (`disable_print_result`, `bench_stream_progress`) are popped before `parse_model(**kwargs)` is called. So the engine always ran `prefill`:

- op workloads got `attn_mode="prefill"` regardless of CLI flag
- the prefill-only `num_layers -= num_mirror_layers` cut was applied to decode runs

Fix: fall back to the ctor-set `self.run_mode` (set from the CLI arg at engine.py:41) while keeping the explicit-kwargs override path.

### 2. `latency.csv` `e2e_latency` omitted the layer count (engine.py:382)

`e2e_latency = stage_latency * pp_size` where `stage_latency` is the **one-layer** DAG makespan, so the reported e2e was ~`num_layers`x too small and contradicted `perf_info["e2e_latency"]` (= `total_latency * num_layers`, engine.py:869).

Fix: `e2e_latency = stage_latency * num_layers * pp_size` (`num_layers` is the per-PP-stage layer count, same convention as line 869).

## Verification

Offline targeted harness (bypasses bench server via `__new__`, monkeypatched report dir), plus `py_compile`:

- decode: `run_mode=decode`, `num_layers=64` (mirror layers no longer wrongly subtracted)
- prefill: `num_layers=62` (mirror subtraction logic unchanged)
- latency.csv: `stage=100.0`, `e2e=2000.0` = 100us x 10 layers x pp2